### PR TITLE
Update timetable for 2016

### DIFF
--- a/app.js
+++ b/app.js
@@ -159,7 +159,7 @@ function GetTimetable(code, yr, callback, errorCallback) {
 
         var options = {
             hostname: 'sws.unimelb.edu.au',
-            path: '/2015/Reports/List.aspx?objects=' + code + '&weeks=1-52&days=1-7&periods=1-56&template=module_by_group_list',
+            path: '/2016/Reports/List.aspx?objects=' + code + '&weeks=1-52&days=1-7&periods=1-56&template=module_by_group_list',
             method: 'GET'
         };
 

--- a/static/index.htm
+++ b/static/index.htm
@@ -18,7 +18,7 @@
 	<div id="subjectError"></div>
 
 	<div>
-		<input id="subjectYear" value="2015"> <input id="subjectCode">
+		<input id="subjectYear" value="2016"> <input id="subjectCode">
 		<input type="button" id="addSubject" value="Find">
 	</div>
 


### PR DESCRIPTION
Quick fix to use the 2016 timetable. Should really make it pull the year from the text box on index.htm but this is quicker.